### PR TITLE
use encrypt for secrets

### DIFF
--- a/scripts/add-secrets.sh
+++ b/scripts/add-secrets.sh
@@ -2,10 +2,21 @@
 
 set -euxo pipefail
 
-drone secret add --name destination_image --data "${REGISTRY_NAME}/example/dag-setup-verifier" "${DRONE_GIT_REPO}"
+#!/bin/bash
 
-drone secret add --name image_registry --data "${REGISTRY_NAME}" "${DRONE_GIT_REPO}"
+cat <<EOF
+---
+kind: secret
+name: destination_image
+data: $(drone encrypt user-01/dag-setup-verifier ${REGISTRY_NAME}/example/dag-setup-verifier)
 
-drone secret add --name image_registry_user --data "${IMAGE_REGISTRY_USER}" "${DRONE_GIT_REPO}"
+---
+kind: secret
+name: image_registry_user
+data: $(drone encrypt user-01/dag-setup-verifier ${IMAGE_REGISTRY_USER})
 
-drone secret add --name image_registry_password --data "${IMAGE_REGISTRY_PASSWORD}" "${DRONE_GIT_REPO}"
+---
+kind: secret
+name: image_registry_password
+data: $(drone encrypt user-01/dag-setup-verifier ${IMAGE_REGISTRY_PASSWORD})
+EOF


### PR DESCRIPTION
I would like this script to not use `drone secret add` because that is an enterprise feature

`drone encrypt` is available in the OSS build of the drone server

I would also rather not treat `image_registry` as a secret, since the registry name becomes obfuscated in the logs making the docker tags and push steps unclear