### PR TITLE
use encrypt for secrets

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,10 +25,9 @@ steps:
       mtu: 1410
       build_args: 
         - "MAVEN_REPOS=nexus=http://nexus.infra:8081/repository/maven-public/"
+      registry: nexus.infra.svc.cluster.local
+      repo: nexus.infra.svc.cluster.local/example/dag-setup-verifier
       username:
         from_secret: image_registry_user
       password:
         from_secret: image_registry_password
-      registry: nexus.infra.svc.cluster.local
-      repo:
-        from_secret: destination_image

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,6 @@ steps:
         from_secret: image_registry_user
       password:
         from_secret: image_registry_password
-      registry:
-        from_secret: image_registry
+      registry: nexus.infra.svc.cluster.local
       repo:
         from_secret: destination_image

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ drone info
 Let use set these variables as Drone secrets using the Drone CLI,
 
 ```shell
-./scripts/add-secrets
+./scripts/add-secrets.sh >> .drone.yml
 ```
 
 Now we are all set to verify our DAG setup, do an empty commit and push to the repo to see the build getting started
 
 ```shell
-git commit --allow-empty -m "Verify Setup" -m "Verify Setup"
+git commit --allow-empty -m "Verify Setup"
 ```

--- a/scripts/add-secrets.sh
+++ b/scripts/add-secrets.sh
@@ -5,11 +5,6 @@ set -euxo pipefail
 cat <<EOF
 ---
 kind: secret
-name: destination_image
-data: $(drone encrypt user-01/dag-setup-verifier ${REGISTRY_NAME}/example/dag-setup-verifier)
-
----
-kind: secret
 name: image_registry_user
 data: $(drone encrypt user-01/dag-setup-verifier ${IMAGE_REGISTRY_USER})
 

--- a/scripts/add-secrets.sh
+++ b/scripts/add-secrets.sh
@@ -2,10 +2,19 @@
 
 set -euxo pipefail
 
-drone secret add --name destination_image --data "${REGISTRY_NAME}/example/dag-setup-verifier" "${DRONE_GIT_REPO}"
+cat <<EOF
+---
+kind: secret
+name: destination_image
+data: $(drone encrypt user-01/dag-setup-verifier ${REGISTRY_NAME}/example/dag-setup-verifier)
 
-drone secret add --name image_registry --data "${REGISTRY_NAME}" "${DRONE_GIT_REPO}"
+---
+kind: secret
+name: image_registry_user
+data: $(drone encrypt user-01/dag-setup-verifier ${IMAGE_REGISTRY_USER})
 
-drone secret add --name image_registry_user --data "${IMAGE_REGISTRY_USER}" "${DRONE_GIT_REPO}"
-
-drone secret add --name image_registry_password --data "${IMAGE_REGISTRY_PASSWORD}" "${DRONE_GIT_REPO}"
+---
+kind: secret
+name: image_registry_password
+data: $(drone encrypt user-01/dag-setup-verifier ${IMAGE_REGISTRY_PASSWORD})
+EOF


### PR DESCRIPTION
I would like this script to not use `drone secret add` because that is an enterprise feature

`drone encrypt` is available in the OSS build of the drone server

I would also rather not treat `image_registry` as a secret, since the registry name becomes obfuscated in the logs making the docker tags and push steps unclear